### PR TITLE
Fixed error when name already exists

### DIFF
--- a/frontend/src/components/account/register.js
+++ b/frontend/src/components/account/register.js
@@ -43,9 +43,11 @@ class Register extends Component {
     }).then(() => {
       this.setState({success: true});
     }).catch((error) => {
+      let nonFieldErrors = error.errors.nonFieldErrors;
+
       throw new SubmissionError({
         ...error.errors,
-        _error: error.errors.nonFieldErrors[0] || undefined
+        _error: nonFieldErrors ? nonFieldErrors[0] : undefined
       });
     })
   };


### PR DESCRIPTION
In the event the backend returned errors for only fields that were known, nonFieldErrors would be non-existent and thus index 0 unavailable.